### PR TITLE
Update node examples to use `spotify-web-api-node` and es6

### DIFF
--- a/authorization_code/app.js
+++ b/authorization_code/app.js
@@ -1,3 +1,5 @@
+'use strict'
+
 /**
  * This is an example of a basic node.js script that performs
  * the Authorization Code oAuth2 flow to authenticate against
@@ -7,137 +9,94 @@
  * https://developer.spotify.com/web-api/authorization-guide/#authorization_code_flow
  */
 
-var express = require('express'); // Express web server framework
-var request = require('request'); // "Request" library
-var querystring = require('querystring');
-var cookieParser = require('cookie-parser');
+const Spotify = require('spotify-web-api-node');
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const querystring = require('querystring');
 
-var client_id = '03ffe0cac0a0401aa6673c3cf6d02ced'; // Your client id
-var client_secret = 'a57c43efb9644574a96d6623fb8bfbc2'; // Your client secret
-var redirect_uri = 'http://localhost:8888/callback'; // Your redirect uri
+const CLIENT_ID = '03ffe0cac0a0401aa6673c3cf6d02ced';
+const CLIENT_SECRET = 'a57c43efb9644574a96d6623fb8bfbc2';
+const REDIRECT_URI = 'http://localhost:8888/callback';
+const STATE_KEY = 'spotify_auth_state';
+// your application requests authorization
+const scopes = ['user-read-private', 'user-read-email'];
 
-/**
- * Generates a random string containing numbers and letters
- * @param  {number} length The length of the string
- * @return {string} The generated string
- */
-var generateRandomString = function(length) {
-  var text = '';
-  var possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+// configure spotify
+const spotifyApi = new Spotify({
+  clientId: CLIENT_ID,
+  clientSecret: CLIENT_SECRET,
+  redirectUri: REDIRECT_URI
+});
 
-  for (var i = 0; i < length; i++) {
-    text += possible.charAt(Math.floor(Math.random() * possible.length));
-  }
-  return text;
-};
+/** Generates a random string containing numbers and letters of N characters */
+const generateRandomString = N => (Math.random().toString(36)+Array(N).join('0')).slice(2, N+2);
 
-var stateKey = 'spotify_auth_state';
-
+// configure express app
 var app = express();
-
 app.use(express.static(__dirname + '/public'))
    .use(cookieParser());
 
-app.get('/login', function(req, res) {
-
-  var state = generateRandomString(16);
-  res.cookie(stateKey, state);
-
-  // your application requests authorization
-  var scope = 'user-read-private user-read-email';
-  res.redirect('https://accounts.spotify.com/authorize?' +
-    querystring.stringify({
-      response_type: 'code',
-      client_id: client_id,
-      scope: scope,
-      redirect_uri: redirect_uri,
-      state: state
-    }));
+app.get('/login', (_, res) => {
+  const state = generateRandomString(16);
+  res.cookie(STATE_KEY, state);
+  res.redirect(spotifyApi.createAuthorizeURL(scopes, state));
 });
 
-app.get('/callback', function(req, res) {
+// your application requests refresh and access tokens
+// after checking the state parameter
+app.get('/callback', (req, res) => {
+  const { code, state } = req.query;
+  const storedState = req.cookies ? req.cookies[STATE_KEY] : null;
 
-  // your application requests refresh and access tokens
-  // after checking the state parameter
-
-  var code = req.query.code || null;
-  var state = req.query.state || null;
-  var storedState = req.cookies ? req.cookies[stateKey] : null;
-
+  // first do state validation
   if (state === null || state !== storedState) {
     res.redirect('/#' +
       querystring.stringify({
         error: 'state_mismatch'
       }));
+  // if the state is valid, get the authorization code and pass it on to the client
   } else {
-    res.clearCookie(stateKey);
-    var authOptions = {
-      url: 'https://accounts.spotify.com/api/token',
-      form: {
-        code: code,
-        redirect_uri: redirect_uri,
-        grant_type: 'authorization_code'
-      },
-      headers: {
-        'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64'))
-      },
-      json: true
-    };
+    res.clearCookie(STATE_KEY);
+    // Retrieve an access token and a refresh token
+    spotifyApi.authorizationCodeGrant(code).then(data => {
+      const { expires_in, access_token, refresh_token } = data.body;
 
-    request.post(authOptions, function(error, response, body) {
-      if (!error && response.statusCode === 200) {
+      // Set the access token on the API object to use it in later calls
+      spotifyApi.setAccessToken(access_token);
+      spotifyApi.setRefreshToken(refresh_token);
 
-        var access_token = body.access_token,
-            refresh_token = body.refresh_token;
+      // use the access token to access the Spotify Web API
+      spotifyApi.getMe().then(({ body }) => {
+        console.log(body);
+      });
 
-        var options = {
-          url: 'https://api.spotify.com/v1/me',
-          headers: { 'Authorization': 'Bearer ' + access_token },
-          json: true
-        };
-
-        // use the access token to access the Spotify Web API
-        request.get(options, function(error, response, body) {
-          console.log(body);
-        });
-
-        // we can also pass the token to the browser to make requests from there
-        res.redirect('/#' +
-          querystring.stringify({
-            access_token: access_token,
-            refresh_token: refresh_token
-          }));
-      } else {
-        res.redirect('/#' +
-          querystring.stringify({
-            error: 'invalid_token'
-          }));
-      }
+      // we can also pass the token to the browser to make requests from there
+      res.redirect('/#' +
+        querystring.stringify({
+          access_token: access_token,
+          refresh_token: refresh_token
+        }));
+    }).catch(err => {
+      res.redirect('/#' +
+        querystring.stringify({
+          error: 'invalid_token'
+        }));
     });
   }
 });
 
-app.get('/refresh_token', function(req, res) {
-
-  // requesting access token from refresh token
-  var refresh_token = req.query.refresh_token;
-  var authOptions = {
-    url: 'https://accounts.spotify.com/api/token',
-    headers: { 'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64')) },
-    form: {
-      grant_type: 'refresh_token',
-      refresh_token: refresh_token
-    },
-    json: true
-  };
-
-  request.post(authOptions, function(error, response, body) {
-    if (!error && response.statusCode === 200) {
-      var access_token = body.access_token;
-      res.send({
-        'access_token': access_token
-      });
-    }
+// requesting access token from refresh token
+app.get('/refresh_token', (req, res) => {
+  const { refresh_token } = req.query;
+  if (refresh_token) {
+    spotifyApi.setAccessToken(refresh_token);
+  }
+  spotifyApi.refreshAccessToken().then(({body}) =>  {
+    res.send({
+      'access_token': body.access_token
+    })
+  }).catch(err => {
+    console.log('Could not refresh access token', err);
   });
 });
 

--- a/authorization_code/app.js
+++ b/authorization_code/app.js
@@ -89,7 +89,7 @@ app.get('/callback', (req, res) => {
 app.get('/refresh_token', (req, res) => {
   const { refresh_token } = req.query;
   if (refresh_token) {
-    spotifyApi.setAccessToken(refresh_token);
+    spotifyApi.setRefreshToken(refresh_token);
   }
   spotifyApi.refreshAccessToken().then(({body}) =>  {
     res.send({

--- a/client_credentials/app.js
+++ b/client_credentials/app.js
@@ -1,3 +1,5 @@
+'use-strict'
+
 /**
  * This is an example of a basic node.js script that performs
  * the Client Credentials oAuth2 flow to authenticate against
@@ -7,38 +9,23 @@
  * https://developer.spotify.com/web-api/authorization-guide/#client_credentials_flow
  */
 
-var request = require('request'); // "Request" library
+const Spotify = require('spotify-web-api-node');
 
-var client_id = '03ffe0cac0a0401aa6673c3cf6d02ced'; // Your client id
-var client_secret = 'a57c43efb9644574a96d6623fb8bfbc2'; // Your client secret
-var redirect_uri = 'http://localhost:8888/callback'; // Your redirect uri
+const CLIENT_ID = '03ffe0cac0a0401aa6673c3cf6d02ced';
+const CLIENT_SECRET = 'a57c43efb9644574a96d6623fb8bfbc2';
 
-// your application requests authorization
-var authOptions = {
-  url: 'https://accounts.spotify.com/api/token',
-  headers: {
-    'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64'))
-  },
-  form: {
-    grant_type: 'client_credentials'
-  },
-  json: true
-};
+// configure spotify
+const spotifyApi = new Spotify({
+  clientId: CLIENT_ID,
+  clientSecret: CLIENT_SECRET
+});
 
-request.post(authOptions, function(error, response, body) {
-  if (!error && response.statusCode === 200) {
-
-    // use the access token to access the Spotify Web API
-    var token = body.access_token;
-    var options = {
-      url: 'https://api.spotify.com/v1/users/jmperezperez',
-      headers: {
-        'Authorization': 'Bearer ' + token
-      },
-      json: true
-    };
-    request.get(options, function(error, response, body) {
-      console.log(body);
-    });
-  }
+// use the access token to access the Spotify Web API
+spotifyApi.clientCredentialsGrant().then(({ body }) => {
+  spotifyApi.setAccessToken(body.access_token);
+  return spotifyApi.getUser('jmperezperez');
+}).then(({ body }) => {
+  console.log(body);
+}).catch(err => {
+  console.error('error getting user info', err);
 });

--- a/package.json
+++ b/package.json
@@ -4,10 +4,17 @@
   "description": "Basic examples of the Spotify authorization flows through oAuth2",
   "version": "0.0.1",
   "main": "app.js",
+  "scripts": {
+    "start-auth-code": "node --harmony_destructuring  authorization_code/app.js"
+  },
   "dependencies": {
     "cookie-parser": "1.3.2",
     "express": "~4.0.0",
     "querystring": "~0.2.0",
-    "request": "~2.34.0"
+    "request": "~2.34.0",
+    "spotify-web-api-node": "^2.2.0"
+  },
+  "engines": {
+    "node": ">5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "version": "0.0.1",
   "main": "app.js",
   "scripts": {
-    "start-auth-code": "node --harmony_destructuring  authorization_code/app.js"
+    "start-auth-code": "node --harmony_destructuring authorization_code/app.js",
+    "start-client-cred": "node --harmony_destructuring client_credentials/app.js"
   },
   "dependencies": {
     "cookie-parser": "1.3.2",


### PR DESCRIPTION
Updated `authorization/app.js` and `client_credentials/app.js` to use the npm module `spotify-web-api-node` and es6 syntax.

I was going through the ["Beginner's Guide" which](https://developer.spotify.com/web-api/tutorial/) (which links to this repo), and found it would be beneficial to have updated examples using this library and a more modern syntax. It makes the examples more digestible and less complex (and also removed a bunch of lines! woo!)

The client code is untouched and is still fully functional with this updated node code
