### PR TITLE
Pass on full body on `/refresh_token` success.

### DIFF
--- a/authorization_code/app.js
+++ b/authorization_code/app.js
@@ -133,10 +133,7 @@ app.get('/refresh_token', function(req, res) {
 
   request.post(authOptions, function(error, response, body) {
     if (!error && response.statusCode === 200) {
-      var access_token = body.access_token;
-      res.send({
-        'access_token': access_token
-      });
+      res.send(body);
     }
   });
 });


### PR DESCRIPTION
The success message on refresh may contain a new refresh token
and an updated expire time which is obscured by the filtering.