### PR TITLE
Fix oauth-template update on /me API call success.

### DIFF
--- a/implicit_grant/public/index.html
+++ b/implicit_grant/public/index.html
@@ -119,6 +119,7 @@
                 },
                 success: function(response) {
                   userProfilePlaceholder.innerHTML = userProfileTemplate(response);
+                  oauthPlaceholder.innerHTML = oauthTemplate(params);
 
                   $('#login').hide();
                   $('#loggedin').show();


### PR DESCRIPTION
Hi,

In the Implicit Grant demo, looks like the the `oauthTemplate` Handlebars template is created but never used. Fixing this!

Thanks,

Tim