### PR TITLE
Axios

### DIFF
--- a/authorization_code/app.js
+++ b/authorization_code/app.js
@@ -81,7 +81,6 @@ app.get('/callback', function(req, res) {
         grant_type: 'authorization_code'
       },
       headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
         'Authorization': 'Basic ' + (new Buffer.from(`${client_id}:${client_secret}`).toString('base64'))
       },
       json: true

--- a/client_credentials/app.js
+++ b/client_credentials/app.js
@@ -7,7 +7,8 @@
  * https://developer.spotify.com/web-api/authorization-guide/#client_credentials_flow
  */
 
-var request = require('request'); // "Request" library
+var axios = require('axios');
+var querystring = require('querystring');
 
 var client_id = 'CLIENT_ID'; // Your client id
 var client_secret = 'CLIENT_SECRET'; // Your secret
@@ -16,7 +17,7 @@ var client_secret = 'CLIENT_SECRET'; // Your secret
 var authOptions = {
   url: 'https://accounts.spotify.com/api/token',
   headers: {
-    'Authorization': 'Basic ' + (new Buffer(client_id + ':' + client_secret).toString('base64'))
+    'Authorization': 'Basic ' + (new Buffer.from(`${client_id}:${client_secret}`).toString('base64'))
   },
   form: {
     grant_type: 'client_credentials'
@@ -24,11 +25,10 @@ var authOptions = {
   json: true
 };
 
-request.post(authOptions, function(error, response, body) {
-  if (!error && response.statusCode === 200) {
-
+axios.post(authOptions.url, querystring.stringify(authOptions.form), authOptions).then(response => {
+  if (response.status === 200) {
     // use the access token to access the Spotify Web API
-    var token = body.access_token;
+    var token = response.data.access_token;
     var options = {
       url: 'https://api.spotify.com/v1/users/jmperezperez',
       headers: {
@@ -36,8 +36,8 @@ request.post(authOptions, function(error, response, body) {
       },
       json: true
     };
-    request.get(options, function(error, response, body) {
-      console.log(body);
+    axios.get(options.url, options).then(response => {
+      console.log(response.data);
     });
   }
 });

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Basic examples of the Spotify authorization flows through OAuth 2",
   "version": "0.0.2",
   "dependencies": {
+    "axios": "^1.1.3",
     "cookie-parser": "1.3.2",
     "express": "~4.16.0",
     "cors": "^2.8.4",
-    "querystring": "~0.2.0",
-    "request": "~2.83.0"
+    "querystring": "~0.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Basic examples of the Spotify authorization flows through OAuth 2",
   "version": "0.0.2",
   "dependencies": {
-    "axios": "^1.1.3",
     "cookie-parser": "1.3.2",
     "express": "~4.16.0",
     "cors": "^2.8.4",
-    "querystring": "~0.2.0"
+    "querystring": "~0.2.0",
+    "axios": "^1.1.3"
   }
 }


### PR DESCRIPTION
Switch from using requests library to axios for post and get calls ([The requests library has been deprecated](https://github.com/request/request/issues/3142)).

The [axios package](https://www.npmjs.com/package/axios) has been [listed as an alternative by the requests developers](https://github.com/request/request/issues/3143).

Also addresses some deprecation warnings for creating Buffers ([See nodejs page here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/)).

Resolves this GitHub issue:
- https://github.com/spotify/web-api-auth-examples/issues/49